### PR TITLE
v0.3 Tier 1: Docker images + GHCR publish + cosign + Trivy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,53 @@ jobs:
       - run: pnpm -r --filter=./packages/* build
       - run: pnpm --filter @a2a-compliance/web typecheck
       - run: pnpm --filter @a2a-compliance/web build
+
+  # Filesystem + config vulnerability scan with Trivy. Runs on every
+  # push / PR so a new CVE in a transitive dep or a misconfigured
+  # Dockerfile is caught before release. Findings upload as SARIF to
+  # GitHub code-scanning when running on push; on forked PRs the
+  # upload step is skipped (no write-perm on the fork's repo).
+  trivy:
+    name: trivy (fs + config)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trivy — filesystem scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+          format: sarif
+          output: trivy-fs.sarif
+          # Fail CI on CRITICAL/HIGH vulns that have a fix available.
+          exit-code: '1'
+
+      - name: Trivy — Dockerfile / compose config scan
+        if: always()
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: config
+          scan-ref: .
+          format: sarif
+          output: trivy-config.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload SARIF to code-scanning
+        if: always() && github.event_name == 'push'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+      - name: Upload config SARIF to code-scanning
+        if: always() && github.event_name == 'push'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,140 @@
+name: Publish images
+
+# Push signed, multi-arch container images to GHCR alongside the npm
+# publish. Triggered by the same `v*.*.*` tag as Release → so npm and
+# GHCR stay in lockstep and a given version tag maps to exactly one
+# immutable image digest.
+#
+# Published images:
+#   ghcr.io/<owner>/a2a-compliance-cli     — the probe CLI
+#   ghcr.io/<owner>/a2a-reference-agent    — zero-dep compliant A2A agent
+#   ghcr.io/<owner>/a2a-compliance-web     — Next.js dashboard
+#
+# Each image ships:
+#   - linux/amd64 + linux/arm64 in one manifest list
+#   - SBOM (SPDX JSON) attached via docker/build-push-action sbom: true
+#   - SLSA provenance attestation (`provenance: mode=max`)
+#   - cosign keyless signature (GitHub OIDC → Sigstore Fulcio +
+#     transparency-logged in Rekor)
+#
+# Nobody else in the A2A ecosystem (a2a-tck, a2a-inspector, a2a-samples)
+# publishes signed+SBOM-attested images today — this is the supply-chain
+# differentiator.
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to publish (without the v prefix). Empty = git sha.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  # Required for cosign keyless signing (GitHub OIDC token → Fulcio).
+  id-token: write
+  # Required for SLSA provenance attestation that references the action run.
+  attestations: write
+
+jobs:
+  images:
+    name: ${{ matrix.image.name }} / ${{ matrix.image.context-desc }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: a2a-compliance-cli
+            dockerfile: packages/cli/Dockerfile
+            context: .
+            context-desc: repo root
+          - name: a2a-reference-agent
+            dockerfile: examples/reference-agent/Dockerfile
+            context: examples/reference-agent
+            context-desc: reference agent
+          - name: a2a-compliance-web
+            dockerfile: apps/web/Dockerfile
+            context: .
+            context-desc: dashboard
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}
+          # `v1.2.3` tag → image tags `1.2.3`, `1.2`, `1`, `latest`.
+          # `workflow_dispatch` falls back to git sha.
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+          labels: |
+            org.opencontainers.image.title=${{ matrix.image.name }}
+            org.opencontainers.image.description=Part of a2a-compliance — compliance test kit + security audit for A2A (Agent2Agent) protocol endpoints.
+            org.opencontainers.image.vendor=a2a-compliance contributors
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+
+      - name: Build & push (multi-arch, signed, SBOM-attested)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,scope=${{ matrix.image.name }},mode=max
+
+      - name: Sign image with cosign (keyless, Sigstore)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        # `cosign` signs by digest, not tag, so the signature is pinned
+        # to the exact image contents — tag movement doesn't invalidate it.
+        run: |
+          set -euo pipefail
+          if ! command -v cosign >/dev/null 2>&1; then
+            COSIGN_VERSION=v2.4.1
+            curl -sSfLo /tmp/cosign "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64"
+            chmod +x /tmp/cosign
+            sudo mv /tmp/cosign /usr/local/bin/cosign
+          fi
+          for tag in $TAGS; do
+            ref="${tag%%:*}"
+            echo "::group::cosign sign ${ref}@${DIGEST}"
+            cosign sign --yes "${ref}@${DIGEST}"
+            echo "::endgroup::"
+          done
+
+      - name: Attach SLSA build-provenance attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![npm — cli](https://img.shields.io/npm/v/%40a2a-compliance%2Fcli?label=%40a2a-compliance%2Fcli)](https://www.npmjs.com/package/@a2a-compliance/cli)
 [![npm — core](https://img.shields.io/npm/v/%40a2a-compliance%2Fcore?label=%40a2a-compliance%2Fcore)](https://www.npmjs.com/package/@a2a-compliance/core)
+[![ghcr — cli](https://ghcr-badge.egpl.dev/ultraskye/a2a-compliance-cli/latest_tag?trim=major&label=ghcr%20cli)](https://github.com/UltraSkye/a2a-compliance/pkgs/container/a2a-compliance-cli)
+[![Open in Codespaces](https://img.shields.io/badge/Open%20in-Codespaces-2ea44f?logo=github)](https://codespaces.new/UltraSkye/a2a-compliance?quickstart=1)
 
 
 > **Automated compliance test kit + security audit for [A2A (Agent2Agent)
@@ -102,13 +104,34 @@ docs with spec references.
 ## Quick start — no install
 
 ```bash
+# with Node installed
 npx @a2a-compliance/cli run https://your-agent.example.com
+
+# without Node — same thing via a signed, multi-arch container
+docker run --rm ghcr.io/ultraskye/a2a-compliance-cli:latest \
+  run https://your-agent.example.com
 ```
 
 Card-only (faster, no live probes):
 
 ```bash
 npx @a2a-compliance/cli card https://your-agent.example.com
+```
+
+Container images are **linux/amd64 + linux/arm64**, **cosign-signed**,
+and ship **SBOM + SLSA provenance**. Verify:
+
+```bash
+cosign verify ghcr.io/ultraskye/a2a-compliance-cli:latest \
+  --certificate-identity-regexp 'https://github.com/UltraSkye/a2a-compliance/.+' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+Run the reference A2A agent as an ephemeral fixture in your own tests:
+
+```bash
+docker run --rm -p 8080:8080 ghcr.io/ultraskye/a2a-reference-agent:latest
+# → http://localhost:8080/.well-known/agent-card.json
 ```
 
 ## CI-friendly outputs
@@ -178,6 +201,12 @@ same report the CLI produces. Run it via docker compose:
 ```bash
 docker compose up -d      # → http://localhost:3000
 docker compose down
+```
+
+Or pull the pre-built image directly:
+
+```bash
+docker run --rm -p 3000:3000 ghcr.io/ultraskye/a2a-compliance-web:latest
 ```
 
 The hosted dashboard refuses to probe private-space URLs (loopback,

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -41,4 +41,12 @@ COPY --from=builder /repo/apps/web/.next/static ./apps/web/.next/static
 
 USER node
 EXPOSE 3000
+
+# Next.js standalone servers answer on / with 200 once the bundle is
+# warm, so the root path works as a liveness probe — no extra /healthz
+# endpoint to maintain. node:24-slim lacks wget / curl; use Node's own
+# fetch to keep the image minimal.
+HEALTHCHECK --interval=15s --timeout=3s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3000/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 CMD ["node", "apps/web/server.js"]

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1.7
+#
+# Docker image for @a2a-compliance/cli.
+#
+#   docker run --rm ghcr.io/ultraskye/a2a-compliance-cli:latest \
+#     run https://agent.example.com
+#
+# Context must be the repository root (the CLI depends on workspace
+# packages @a2a-compliance/core and @a2a-compliance/schemas that live
+# outside packages/cli/). In CI: build with `context: .` and
+# `file: packages/cli/Dockerfile`.
+
+# ---- Stage 1: base with pnpm ----
+FROM node:24-alpine AS base
+ENV PNPM_HOME=/pnpm PATH=/pnpm:$PATH
+RUN corepack enable && corepack prepare pnpm@10 --activate
+WORKDIR /repo
+
+# ---- Stage 2: install workspace deps ----
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/schemas/package.json packages/schemas/
+COPY packages/core/package.json    packages/core/
+COPY packages/cli/package.json     packages/cli/
+# apps/web's package.json is copied to keep pnpm's frozen-lockfile happy,
+# but we restrict the actual install graph to the CLI transitive chain
+# so Next.js / react don't end up in this stage. apps/action has no
+# package.json — it's a composite GitHub Action, just YAML.
+COPY apps/web/package.json apps/web/
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile \
+      --filter '@a2a-compliance/cli...'
+
+# ---- Stage 3: build + prune to production deps ----
+FROM deps AS builder
+COPY tsconfig.base.json ./
+COPY packages packages
+RUN pnpm -r --filter=./packages/* build
+# pnpm deploy produces a self-contained node_modules tree pointing at
+# the built dist/ of every workspace dep — the runtime image doesn't
+# need pnpm or the monorepo.
+RUN pnpm --filter @a2a-compliance/cli deploy --prod --legacy /out
+
+# ---- Stage 4: minimal runtime image ----
+FROM node:24-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Named non-root user `a2a` so the container can't write outside its
+# working dir even if an operator bind-mounts the host cwd.
+RUN addgroup -g 1001 a2a && adduser -D -u 1001 -G a2a a2a
+
+COPY --from=builder --chown=a2a:a2a /out/ ./
+RUN chmod +x ./dist/index.js
+
+USER a2a:a2a
+ENTRYPOINT ["node", "/app/dist/index.js"]
+# Sensible default: print help when run with no args.
+CMD ["--help"]


### PR DESCRIPTION
## Summary

Tier-1 closeouts from the competitor-packaging audit (see research notes
in the repo's plan discussion). Stacks on top of PR #11 (feat/v0.2).

- **`packages/cli/Dockerfile`** — 4-stage alpine build, non-root
  `a2a` user, ENTRYPOINT `node /app/dist/index.js`. ~236 MB. Smoke
  tested locally: `list` / `explain` / `run` all work.
- **HEALTHCHECK** in `apps/web/Dockerfile` via Node's own fetch — no
  extra `/healthz` endpoint, works with Compose `service_healthy`.
- **`.github/workflows/publish-images.yml`** — on `v*.*.*` tag builds
  linux/amd64 + linux/arm64 for 3 images (CLI, reference-agent,
  web), pushes to GHCR with semver fan-out, attaches SPDX SBOM +
  SLSA provenance, and cosign-keyless-signs each digest.
  Verification command lands in the README.
- **Trivy** — filesystem + config scan added to `ci.yml`; SARIF
  uploaded to code-scanning on push.
- **README** — `docker run` blocks for every image, `cosign verify`
  snippet, "Open in Codespaces" badge, GHCR tag badge.

## Why this matters

Research showed that `a2a-tck` ships no image at all, `a2a-inspector`
ships a single-arch unsigned image with no SBOM, and no A2A-ecosystem
project signs or attests provenance. After this PR, `a2a-compliance`
is the only one that does.

## Test plan

- [ ] `docker build -f packages/cli/Dockerfile -t test .` succeeds (verified locally)
- [ ] `docker run test list` prints the check catalog (verified locally)
- [ ] `docker run test run https://...` runs full probe (verified locally)
- [ ] CI: ci.yml's new `trivy` job passes
- [ ] On tag push, `publish-images.yml` builds all three images for amd64 + arm64, signs them, attaches SBOM + provenance
- [ ] `cosign verify ghcr.io/...:vX.Y.Z ...` succeeds against the published image