### PR TITLE
v0.3.1: fix Dockerfile build scope + publish @a2a-compliance/mcp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,13 @@ jobs:
       - name: Preflight — inspect tarball contents
         run: |
           set -e
-          for pkg in schemas core cli; do
+          for pkg in schemas core cli mcp; do
             echo "::group::@a2a-compliance/$pkg pack contents"
             (cd packages/$pkg && pnpm pack --pack-destination /tmp --dry-run)
             echo "::endgroup::"
           done
           # Hard fail if anyone's tarball forgot LICENSE.
-          for pkg in schemas core cli; do
+          for pkg in schemas core cli mcp; do
             pnpm --filter @a2a-compliance/$pkg pack --pack-destination /tmp > /tmp/pack.log
             tgz=$(ls /tmp/a2a-compliance-$pkg-*.tgz | head -1)
             if ! tar tzf "$tgz" | grep -q 'package/LICENSE'; then
@@ -73,6 +73,11 @@ jobs:
 
       - name: Publish @a2a-compliance/cli
         run: pnpm --filter @a2a-compliance/cli publish --no-git-checks --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @a2a-compliance/mcp
+        run: pnpm --filter @a2a-compliance/mcp publish --no-git-checks --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning: [Semantic Versioning](https://semver.org/).
 
+## [0.3.1] - 2026-04-18
+
+### Fixed
+
+- **`packages/cli/Dockerfile`** — restricted the build step from
+  `pnpm -r --filter=./packages/* build` to
+  `pnpm --filter '@a2a-compliance/cli...' build`. The wildcard tried
+  to compile the new mcp package whose `@modelcontextprotocol/sdk`
+  and `zod` deps weren't installed in the CLI image (the install
+  step had already filtered them out), blocking multi-arch image
+  publishing on the v0.3.0 tag.
+- **`apps/web/Dockerfile`** — same fix: build scoped to
+  `@a2a-compliance/web...`. Also added the missing
+  `packages/mcp/package.json` COPY so pnpm's frozen-lockfile check
+  doesn't fall back to an unlocked resolution path.
+- **`.github/workflows/release.yml`** — added
+  `@a2a-compliance/mcp` to the npm publish list. v0.3.0 shipped the
+  package on the filesystem but the release workflow predated it
+  and skipped publishing.
+
+### Bumped
+
+- `@a2a-compliance/schemas` → 0.3.1
+- `@a2a-compliance/core` → 0.3.1
+- `@a2a-compliance/cli` → 0.3.1
+- `@a2a-compliance/mcp` → 0.3.1
+
 ## [0.3.0] - 2026-04-18
 
 ### Added — packaging + distribution

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -12,19 +12,22 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/schemas/package.json packages/schemas/
 COPY packages/core/package.json    packages/core/
 COPY packages/cli/package.json     packages/cli/
+COPY packages/mcp/package.json     packages/mcp/
 COPY apps/web/package.json         apps/web/
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile
+    pnpm install --frozen-lockfile \
+      --filter '@a2a-compliance/web...'
 
 # ---- Stage 3: build core packages + web app ----
 FROM deps AS builder
 COPY tsconfig.base.json biome.json ./
 COPY packages packages
 COPY apps/web apps/web
-# Next.js uses outputFileTracingRoot to find workspace packages; building
-# the workspace packages first gives the tracer something to resolve.
-RUN pnpm -r --filter=./packages/* build \
- && pnpm --filter @a2a-compliance/web build
+# Build only what `web` transitively depends on. The mcp package is
+# kept out of the graph because its @modelcontextprotocol/sdk + zod
+# deps aren't installed in this image (the deps stage filtered to
+# `@a2a-compliance/web...`).
+RUN pnpm --filter '@a2a-compliance/web...' build
 
 # ---- Stage 4: minimal runtime image ----
 FROM node:24-bookworm-slim AS runner

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -35,7 +35,12 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 FROM deps AS builder
 COPY tsconfig.base.json ./
 COPY packages packages
-RUN pnpm -r --filter=./packages/* build
+# `--filter @a2a-compliance/cli...` builds the CLI plus its transitive
+# workspace deps (schemas + core) — explicitly not the mcp package,
+# whose deps (@modelcontextprotocol/sdk, zod) aren't installed in this
+# image. A bare `pnpm -r --filter=./packages/* build` would try to
+# compile mcp and fail on missing modules.
+RUN pnpm --filter '@a2a-compliance/cli...' build
 # pnpm deploy produces a self-contained node_modules tree pointing at
 # the built dist/ of every workspace dep — the runtime image doesn't
 # need pnpm or the monorepo.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Command-line compliance test kit + security audit for A2A (Agent2Agent) protocol endpoints. Validates agent cards, JSON-RPC conformance, auth, and SSRF/TLS/CORS. Emits JSON, JUnit, SARIF, badge, snapshot diff.",
   "keywords": [
     "a2a",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Library for probing, validating, and reporting on A2A (Agent2Agent) protocol endpoints. Assertion engine + reporters (JSON, JUnit, SARIF 2.1.0, badge SVG, snapshot diff), SSRF guard, DNS-rebinding pin, check catalog. Used by @a2a-compliance/cli.",
   "keywords": [
     "a2a",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Model Context Protocol (MCP) server for the A2A (Agent2Agent) protocol compliance test kit. Lets Claude Desktop, Cursor, Codex, and other MCP clients invoke run_compliance / validate_agent_card / list_checks / explain_check / ssrf_check_url as native tools.",
   "keywords": [
     "a2a",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/schemas",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Zod schemas for the A2A (Agent2Agent) protocol: Agent Card, JSON-RPC 2.0 envelope, Task, Message, Part. Zero runtime deps beyond Zod; runs in Node / Bun / Deno / browser / edge.",
   "keywords": [
     "a2a",


### PR DESCRIPTION
## Summary

Patch release fixing two failures that surfaced on the v0.3.0 tag cascade.

1. **CLI + web Dockerfiles** did `pnpm -r --filter=./packages/* build` which tried to compile `@a2a-compliance/mcp`. The install steps were correctly scoped (`--filter '@a2a-compliance/cli...'` / `--filter '@a2a-compliance/web...'`) so mcp's deps (`@modelcontextprotocol/sdk`, `zod`) were never installed; the build then crashed with `TS2307`. Fixed by scoping the build command the same way. Added missing `packages/mcp/package.json` COPY in the web image for frozen-lockfile integrity.
2. **`release.yml`** predated `@a2a-compliance/mcp` and skipped npm publishing for it. v0.3.0 shipped the package on disk but the registry never saw it. Added it to the preflight + publish block.

All four packages bumped to 0.3.1 to make republish land cleanly. v0.3.0 of schemas/core/cli stays on npm as-is.

## Verified locally

- `docker build -f packages/cli/Dockerfile -t test .` → succeeds.
- `docker run test --version` → `0.3.1`.
- `pnpm lint` / `pnpm typecheck` / `pnpm test` green (228 tests).