### PR TITLE
v0.3.2: close all 7 open code-scanning alerts (CodeQL + Trivy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning: [Semantic Versioning](https://semver.org/).
 
+## [0.3.2] - 2026-04-18
+
+### Security
+
+Closes every open GitHub code-scanning alert (7 total) surfaced by
+CodeQL + Trivy against the v0.3.1 tree.
+
+- **Reference agent** (`examples/reference-agent/server.js`) no longer
+  echoes the raw `Error.message` from its internal-error catch block
+  back to the client — that path could leak internal file paths,
+  module versions, or upstream endpoint fragments. Logs server-side,
+  returns a generic `"internal error"` instead. Fixes CodeQL
+  `js/stack-trace-exposure`.
+- **Reference agent Dockerfile** drops from `root` to the built-in
+  `node` user before starting the server. Fixes Trivy `DS-0002`
+  *Image user should not be 'root'*.
+- **CLI Dockerfile** declares `HEALTHCHECK NONE` — the CLI is a
+  one-shot probe with no long-lived service state to health-check,
+  so `NONE` is the semantically correct answer. Fixes Trivy
+  `DS-0026` *No HEALTHCHECK defined*.
+- **Helm chart** (`charts/a2a-compliance-web/`):
+  - `runAsUser` / `runAsGroup` / `fsGroup` raised to `10001`
+    (Trivy `KSV-0020` / `KSV-0021` — IDs ≤ 10000 may collide with
+    system accounts; 10001+ is also easier to spot in audit logs).
+  - Every template resource declares `namespace: {{ .Release.Namespace }}`
+    explicitly (Trivy `KSV-0110` — no more silent `default`).
+  - `image.digest` added to `values.yaml`. When set, the Deployment
+    uses the digest form (`repo@sha256:...`) instead of a mutable
+    tag, closing Trivy `KSV-0125` *Restrict container images to
+    trusted registries* for operators who pin.
+
+### Bumped
+
+- `@a2a-compliance/{schemas,core,cli,mcp}` → 0.3.2
+- `charts/a2a-compliance-web` → 0.3.2
+
 ## [0.3.1] - 2026-04-18
 
 ### Fixed

--- a/charts/a2a-compliance-web/Chart.yaml
+++ b/charts/a2a-compliance-web/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: a2a-compliance-web
 description: Next.js dashboard for running A2A (Agent2Agent) protocol compliance checks interactively. Refuses private-space targets at the ingress — same SSRF guard the CLI uses.
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.2
+appVersion: "0.3.2"
 keywords:
   - a2a
   - agent2agent

--- a/charts/a2a-compliance-web/templates/deployment.yaml
+++ b/charts/a2a-compliance-web/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "a2a-compliance-web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "a2a-compliance-web.labels" . | nindent 4 }}
 spec:
@@ -26,7 +27,11 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: web
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/a2a-compliance-web/templates/ingress.yaml
+++ b/charts/a2a-compliance-web/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "a2a-compliance-web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "a2a-compliance-web.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/a2a-compliance-web/templates/service.yaml
+++ b/charts/a2a-compliance-web/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "a2a-compliance-web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "a2a-compliance-web.labels" . | nindent 4 }}
 spec:

--- a/charts/a2a-compliance-web/values.yaml
+++ b/charts/a2a-compliance-web/values.yaml
@@ -8,6 +8,12 @@
 image:
   repository: ghcr.io/ultraskye/a2a-compliance-web
   tag: ""  # defaults to Chart.appVersion
+  # Pin to an immutable digest in production for supply-chain
+  # integrity (closes Trivy KSV-0125 trusted-registries alert). When
+  # set, takes precedence over tag. Copy the digest from the
+  # cosign-signed GHCR publication:
+  #   cosign verify ghcr.io/ultraskye/a2a-compliance-web:<version> --certificate-identity-regexp '...'
+  digest: ""
   pullPolicy: IfNotPresent
 
 # Override for private registries / mirrored tags.
@@ -44,11 +50,16 @@ ingress:
 # Apply to every Pod. The dashboard is stateless and reads no
 # filesystem, so a read-only root FS + non-root user closes the
 # blast radius if a downstream container exploit is found.
+#
+# UID/GID are deliberately above 10000 — under 10000 is treated by
+# Trivy rules KSV-0020 / KSV-0021 as a potential collision with
+# system users (node:alpine's "node" account sits at 1000). Using a
+# high, unique uid also makes this pod easy to spot in an audit log.
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
-  fsGroup: 1000
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
   seccompProfile:
     type: RuntimeDefault
 

--- a/examples/reference-agent/Dockerfile
+++ b/examples/reference-agent/Dockerfile
@@ -2,12 +2,18 @@ FROM node:24-alpine
 WORKDIR /app
 
 # Reference agent ships zero runtime deps — no install layer needed.
-COPY package.json server.js ./
+# Chown so the non-root user that runs the process can read them.
+COPY --chown=node:node package.json server.js ./
 
 ENV HOST=0.0.0.0
 ENV PORT=8080
 
 EXPOSE 8080
+
+# node:alpine already has a `node` user (uid/gid 1000). Drop from root
+# before the server starts so a container-escape still lands outside
+# root's capability set. Closes Dockerfile linter rule DS-0002.
+USER node
 
 HEALTHCHECK --interval=10s --timeout=3s --retries=3 \
   CMD wget -q --spider http://127.0.0.1:${PORT}/.well-known/agent-card.json || exit 1

--- a/examples/reference-agent/server.js
+++ b/examples/reference-agent/server.js
@@ -213,7 +213,11 @@ const server = createServer(async (req, res) => {
     res.writeHead(404, { 'Content-Type': 'text/plain' });
     res.end('not found');
   } catch (err) {
-    writeJson(res, 200, jsonRpcError(null, JSONRPC_ERR.InternalError, err?.message ?? String(err)));
+    // Stack traces and raw Error messages can leak internal paths,
+    // module versions, or upstream endpoint details. Log server-side
+    // for the operator; send a generic message to the client.
+    console.error('reference-agent internal error:', err);
+    writeJson(res, 200, jsonRpcError(null, JSONRPC_ERR.InternalError, 'internal error'));
   }
 });
 

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -59,6 +59,14 @@ COPY --from=builder --chown=a2a:a2a /out/ ./
 RUN chmod +x ./dist/index.js
 
 USER a2a:a2a
+
+# The CLI is a one-shot probe — it runs, writes a report, exits. There
+# is no long-lived service state to health-check. `HEALTHCHECK NONE`
+# is the correct declaration for this class of image; without it,
+# Dockerfile linters (Trivy / Hadolint / CodeQL DS-0026) warn that a
+# HEALTHCHECK is missing, even though adding one would be meaningless.
+HEALTHCHECK NONE
+
 ENTRYPOINT ["node", "/app/dist/index.js"]
 # Sensible default: print help when run with no args.
 CMD ["--help"]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Command-line compliance test kit + security audit for A2A (Agent2Agent) protocol endpoints. Validates agent cards, JSON-RPC conformance, auth, and SSRF/TLS/CORS. Emits JSON, JUnit, SARIF, badge, snapshot diff.",
   "keywords": [
     "a2a",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Library for probing, validating, and reporting on A2A (Agent2Agent) protocol endpoints. Assertion engine + reporters (JSON, JUnit, SARIF 2.1.0, badge SVG, snapshot diff), SSRF guard, DNS-rebinding pin, check catalog. Used by @a2a-compliance/cli.",
   "keywords": [
     "a2a",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Model Context Protocol (MCP) server for the A2A (Agent2Agent) protocol compliance test kit. Lets Claude Desktop, Cursor, Codex, and other MCP clients invoke run_compliance / validate_agent_card / list_checks / explain_check / ssrf_check_url as native tools.",
   "keywords": [
     "a2a",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/schemas",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Zod schemas for the A2A (Agent2Agent) protocol: Agent Card, JSON-RPC 2.0 envelope, Task, Message, Part. Zero runtime deps beyond Zod; runs in Node / Bun / Deno / browser / edge.",
   "keywords": [
     "a2a",


### PR DESCRIPTION
## Summary

Clears every open GitHub code-scanning alert surfaced against v0.3.1. Seven findings total — four low, two medium, one high.

| # | Rule | Severity | Fix |
|---|---|---|---|
| 9 | DS-0026 No HEALTHCHECK | low | `HEALTHCHECK NONE` in `packages/cli/Dockerfile` |
| 8 | DS-0002 root user | high | `USER node` + `--chown` in `examples/reference-agent/Dockerfile` |
| 7 | KSV-0125 trusted registry | medium | `image.digest` option in `values.yaml` + Deployment chooses digest form when set |
| 6 | KSV-0110 default namespace | low | Every chart template gets `namespace: {{ .Release.Namespace }}` |
| 5 | KSV-0021 GID ≤ 10000 | low | Helm `fsGroup`/`runAsGroup` → 10001 |
| 4 | KSV-0020 UID ≤ 10000 | low | Helm `runAsUser` → 10001 |
| 3 | js/stack-trace-exposure | medium | `examples/reference-agent/server.js` — log server-side, return generic message |

Bumped schemas/core/cli/mcp + Chart to 0.3.2.

## Verified locally

- `pnpm lint` clean (100 files)
- `pnpm typecheck` clean
- `pnpm test` — 228 tests
- Reference-agent with malformed body now returns `{"error":{"code":-32700,"message":"Parse error"}}` — no internals echoed.