### PR TITLE
chore(release): v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 versioning: [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.3.3] - 2026-04-24
 
 ### Security
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/web",
-  "version": "0.1.0",
+  "version": "0.3.3",
   "private": true,
   "description": "Web dashboard for interactive A2A compliance runs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a2a-compliance",
-  "version": "0.1.0",
+  "version": "0.3.3",
   "private": true,
   "description": "Compliance test kit and validator for A2A (Agent2Agent) protocol endpoints",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Command-line compliance test kit + security audit for A2A (Agent2Agent) protocol endpoints. Validates agent cards, JSON-RPC conformance, auth, and SSRF/TLS/CORS. Emits JSON, JUnit, SARIF, badge, snapshot diff.",
   "keywords": [
     "a2a",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/core",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Library for probing, validating, and reporting on A2A (Agent2Agent) protocol endpoints. Assertion engine + reporters (JSON, JUnit, SARIF 2.1.0, badge SVG, snapshot diff), SSRF guard, DNS-rebinding pin, check catalog. Used by @a2a-compliance/cli.",
   "keywords": [
     "a2a",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Model Context Protocol (MCP) server for the A2A (Agent2Agent) protocol compliance test kit. Lets Claude Desktop, Cursor, Codex, and other MCP clients invoke run_compliance / validate_agent_card / list_checks / explain_check / ssrf_check_url as native tools.",
   "keywords": [
     "a2a",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2a-compliance/schemas",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Zod schemas for the A2A (Agent2Agent) protocol: Agent Card, JSON-RPC 2.0 envelope, Task, Message, Part. Zero runtime deps beyond Zod; runs in Node / Bun / Deno / browser / edge.",
   "keywords": [
     "a2a",


### PR DESCRIPTION
Version bump + CHANGELOG promote for v0.3.3 security audit.

Tag v0.3.3 already pushed — `release.yml` is publishing to npm
and cutting the GitHub Release. This PR syncs main to include
the bump commit.

See #17 for the underlying fixes.